### PR TITLE
Resolve NPE

### DIFF
--- a/avatica/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
+++ b/avatica/src/main/java/org/apache/calcite/avatica/jdbc/JdbcMeta.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -374,7 +375,12 @@ public class JdbcMeta implements Meta {
   }
 
   public Signature prepare(StatementHandle h, String sql, int maxRowCount) {
-    return null;
+    // TODO: can't actually prepare an existing statement...
+    try (PreparedStatement statement = connection.prepareStatement(sql)) {
+      return signature(statement.getMetaData(), sql);
+    } catch (SQLException e) {
+      throw propagate(e);
+    }
   }
 
   public MetaResultSet prepareAndExecute(StatementHandle h, String sql,


### PR DESCRIPTION
```
java.sql.SQLException: while executing SQL: select * from STOCK_SYMBOL
        at org.apache.calcite.avatica.Helper.createException(Helper.java:39)
        at org.apache.calcite.avatica.AvaticaStatement.execute(AvaticaStatement.java:97)
        at sqlline.Commands.execute(Commands.java:822)
        at sqlline.Commands.sql(Commands.java:732)
        at sqlline.SqlLine.dispatch(SqlLine.java:808)
        at sqlline.SqlLine.begin(SqlLine.java:681)
        at sqlline.SqlLine.start(SqlLine.java:398)
        at sqlline.SqlLine.main(SqlLine.java:292)
Caused by: java.lang.NullPointerException
        at org.apache.calcite.avatica.AvaticaResultSet.<init>(AvaticaResultSet.java:78)
        at org.apache.calcite.avatica.AvaticaJdbc41Factory.newResultSet(AvaticaJdbc41Factory.java:90)
        at org.apache.calcite.avatica.AvaticaConnection.executeQueryInternal(AvaticaConnection.java:414)
        at org.apache.calcite.avatica.AvaticaStatement.executeQueryInternal(AvaticaStatement.java:394)
        at org.apache.calcite.avatica.AvaticaStatement.executeInternal(AvaticaStatement.java:377)
        at org.apache.calcite.avatica.AvaticaStatement.execute(AvaticaStatement.java:95)
        ... 6 more
```
