### PR TITLE
Get ready for symmetric aggregates

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -783,7 +783,7 @@ public abstract class SqlImplementor {
           SqlNode fieldOperand = field(ordinal);
           return SqlStdOperatorTable.CURSOR.createCall(SqlParserPos.ZERO, fieldOperand);
         }
-        if (ignoreCast || SqlTypeName.UNKNOWN.equals(call.getType().getSqlTypeName())) {
+        if (ignoreCast || call.getType().getSqlTypeName() == SqlTypeName.UNKNOWN) {
           assert nodeList.size() == 1;
           return nodeList.get(0);
         } else {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -783,7 +783,7 @@ public abstract class SqlImplementor {
           SqlNode fieldOperand = field(ordinal);
           return SqlStdOperatorTable.CURSOR.createCall(SqlParserPos.ZERO, fieldOperand);
         }
-        if (ignoreCast) {
+        if (ignoreCast || SqlTypeName.UNKNOWN.equals(call.getType().getSqlTypeName())) {
           assert nodeList.size() == 1;
           return nodeList.get(0);
         } else {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -783,6 +783,11 @@ public abstract class SqlImplementor {
           SqlNode fieldOperand = field(ordinal);
           return SqlStdOperatorTable.CURSOR.createCall(SqlParserPos.ZERO, fieldOperand);
         }
+        // Ideally the UNKNOWN type would never exist in a fully-formed, validated rel node, but
+        // it can be useful in certain situations where determining the type of an expression is
+        // infeasible, such as inserting arbitrary user-provided SQL snippets into an otherwise
+        // manually-constructed (as opposed to parsed) rel node.
+        // In such a context, assume that casting anything to UNKNOWN is a no-op.
         if (ignoreCast || call.getType().getSqlTypeName() == SqlTypeName.UNKNOWN) {
           assert nodeList.size() == 1;
           return nodeList.get(0);

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -40,7 +40,7 @@ public class BasicSqlType extends AbstractSqlType {
 
   private final int precision;
   private final int scale;
-  private final RelDataTypeSystem typeSystem;
+  protected final RelDataTypeSystem typeSystem;
   private final @Nullable SqlCollation collation;
   private final @Nullable SerializableCharset wrappedCharset;
 
@@ -54,7 +54,11 @@ public class BasicSqlType extends AbstractSqlType {
    * @param typeName Type name
    */
   public BasicSqlType(RelDataTypeSystem typeSystem, SqlTypeName typeName) {
-    this(typeSystem, typeName, false, PRECISION_NOT_SPECIFIED,
+    this(typeSystem, typeName, false);
+  }
+
+  public BasicSqlType(RelDataTypeSystem typeSystem, SqlTypeName typeName, boolean nullable) {
+    this(typeSystem, typeName, nullable, PRECISION_NOT_SPECIFIED,
         SCALE_NOT_SPECIFIED, null, null);
     checkPrecScale(typeName, false, false);
   }

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -571,8 +571,20 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
   /** The unknown type. Similar to the NULL type, but is only equal to
    * itself. */
   private static class UnknownSqlType extends BasicSqlType {
+
     UnknownSqlType(RelDataTypeFactory typeFactory) {
-      super(typeFactory.getTypeSystem(), SqlTypeName.NULL);
+      this(typeFactory.getTypeSystem(), false);
+    }
+
+    private UnknownSqlType(RelDataTypeSystem typeSystem, boolean nullable) {
+      super(typeSystem, SqlTypeName.UNKNOWN, nullable);
+    }
+
+    @Override BasicSqlType createWithNullability(boolean nullable) {
+      if (nullable == this.isNullable) {
+        return this;
+      }
+      return new UnknownSqlType(this.typeSystem, nullable);
     }
 
     @Override protected void generateTypeString(StringBuilder sb,

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -570,7 +570,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
 
   /** The unknown type. Similar to the NULL type, but is only equal to
    * itself. */
-  private static class UnknownSqlType extends BasicSqlType {
+  static class UnknownSqlType extends BasicSqlType {
 
     UnknownSqlType(RelDataTypeFactory typeFactory) {
       this(typeFactory.getTypeSystem(), false);

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeMappingRule.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeMappingRule.java
@@ -44,9 +44,9 @@ public interface SqlTypeMappingRule {
     Objects.requireNonNull(to, "to");
     Objects.requireNonNull(from, "from");
 
-    if (to == SqlTypeName.NULL) {
+    if (to == SqlTypeName.NULL || to == SqlTypeName.UNKNOWN) {
       return false;
-    } else if (from == SqlTypeName.NULL) {
+    } else if (from == SqlTypeName.NULL || from == SqlTypeName.UNKNOWN) {
       return true;
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -106,6 +106,7 @@ public enum SqlTypeName {
   VARBINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY,
       SqlTypeFamily.BINARY),
   NULL(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
+  UNKNOWN(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
   ANY(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, true,
       Types.JAVA_OBJECT, SqlTypeFamily.ANY),
   SYMBOL(PrecScale.NO_NO, true, Types.OTHER, null),

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -824,6 +824,9 @@ public abstract class SqlTypeUtil {
 
     final SqlTypeName fromTypeName = fromType.getSqlTypeName();
     final SqlTypeName toTypeName = toType.getSqlTypeName();
+    if (toTypeName == SqlTypeName.UNKNOWN) {
+      return true;
+    }
     if (toType.isStruct() || fromType.isStruct()) {
       if (toTypeName == SqlTypeName.DISTINCT) {
         if (fromTypeName == SqlTypeName.DISTINCT) {

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl.UnknownSqlType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -33,6 +34,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -278,4 +280,18 @@ class SqlTypeFactoryTest {
     assertThat(tsWithPrecision3 == tsWithPrecision8, is(true));
   }
 
+  /** Test that the {code UNKNOWN} type does not does not change class when nullified. */
+  @Test void testUnknownCreateWithNullabiliityTypeConsistency() {
+    SqlTypeFixture f = new SqlTypeFixture();
+
+    RelDataType unknownType  = f.typeFactory.createUnknownType();
+    assertThat(unknownType, isA(UnknownSqlType.class));
+    assertThat(unknownType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
+    assertFalse(unknownType.isNullable());
+
+    RelDataType nullableRelDataType = f.typeFactory.createTypeWithNullability(unknownType, true);
+    assertThat(nullableRelDataType, isA(UnknownSqlType.class));
+    assertThat(nullableRelDataType.getSqlTypeName(), is(SqlTypeName.UNKNOWN));
+    assertTrue(nullableRelDataType.isNullable());
+  }
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -281,7 +281,7 @@ class SqlTypeFactoryTest {
   }
 
   /** Test that the {code UNKNOWN} type does not does not change class when nullified. */
-  @Test void testUnknownCreateWithNullabiliityTypeConsistency() {
+  @Test void testUnknownCreateWithNullabilityTypeConsistency() {
     SqlTypeFixture f = new SqlTypeFixture();
 
     RelDataType unknownType  = f.typeFactory.createUnknownType();

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -38,6 +38,7 @@ import static org.apache.calcite.sql.type.SqlTypeUtil.equalAsMapSansNullability;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link org.apache.calcite.sql.type.SqlTypeUtil}.
@@ -225,5 +226,30 @@ class SqlTypeUtilTest {
 
     compareTypesIgnoringNullability("identical types should return true.",
         bigIntType, bigIntType1, true);
+  }
+
+  @Test public void testCanAlwaysCastToUnknownFromBasic() {
+    RelDataType unknownType = f.typeFactory.createUnknownType();
+    RelDataType nullableUnknownType = f.typeFactory.createTypeWithNullability(unknownType, true);
+
+    for (SqlTypeName fromTypeName : SqlTypeName.values()) {
+      BasicSqlType fromType;
+      try {
+        // This only works for basic types. Ignore the rest.
+        fromType = (BasicSqlType) f.typeFactory.createSqlType(fromTypeName);
+      } catch (AssertionError e) {
+        continue;
+      }
+      BasicSqlType nullableFromType = fromType.createWithNullability(!fromType.isNullable);
+
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, true));
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, true));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, true));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, false));
+      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, true));
+    }
   }
 }

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -38,7 +38,6 @@ import static org.apache.calcite.sql.type.SqlTypeUtil.equalAsMapSansNullability;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link org.apache.calcite.sql.type.SqlTypeUtil}.
@@ -242,14 +241,21 @@ class SqlTypeUtilTest {
       }
       BasicSqlType nullableFromType = fromType.createWithNullability(!fromType.isNullable);
 
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, fromType, true));
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(unknownType, nullableFromType, true));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, fromType, true));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, false));
-      assertTrue(SqlTypeUtil.canCastFrom(nullableUnknownType, nullableFromType, true));
+      assertCanCast(unknownType, fromType);
+      assertCanCast(unknownType, nullableFromType);
+      assertCanCast(nullableUnknownType, fromType);
+      assertCanCast(nullableUnknownType, nullableFromType);
     }
+  }
+
+  private static void assertCanCast(RelDataType toType, RelDataType fromType) {
+    assertThat(
+        String.format(
+            "Expected to be able to cast from %s to %s without coercion.", fromType, toType),
+        SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ false), is(true));
+    assertThat(
+        String.format(
+            "Expected to be able to cast from %s to %s with coercion.", fromType, toType),
+        SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ true), is(true));
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -6229,6 +6229,16 @@ class RelOptRulesTest extends RelOptTestBase {
     sql(sql).withRule(rule).check();
   }
 
+  @Test void testReduceWithNonTypePredicate() {
+    // Make sure we can reduce with more specificity than just agg function type.
+    final RelOptRule rule = AggregateReduceFunctionsRule.Config.DEFAULT
+        .withExtraCondition(call -> call.distinctKeys != null)
+        .toRule();
+    final String sql = "select avg(sal), avg(sal) within distinct (deptno)\n"
+        + "from emp";
+    sql(sql).withRule(rule).check();
+  }
+
   /** Test case for
   * <a href="https://issues.apache.org/jira/browse/CALCITE-2803">[CALCITE-2803]
   * Identify expanded IS NOT DISTINCT FROM expression when pushing project past join</a>.

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -9674,6 +9674,28 @@ LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReduceWithNonTypePredicate">
+    <Resource name="sql">
+      <![CDATA[select avg(sal), avg(sal) within distinct (deptno)
+from emp]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], EXPR$1=[AVG($0) WITHIN DISTINCT ($1)])
+  LogicalProject(SAL=[$5], DEPTNO=[$7])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0], EXPR$1=[CAST(/($1, $2)):INTEGER])
+  LogicalProject(EXPR$0=[$0], $f1=[CASE(=($2, 0), null:INTEGER, $1)], $f2=[$2])
+    LogicalAggregate(group=[{}], EXPR$0=[AVG($0)], agg#1=[$SUM0($0) WITHIN DISTINCT ($1)], agg#2=[COUNT() WITHIN DISTINCT ($1)])
+      LogicalProject(SAL=[$5], DEPTNO=[$7])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testReduceAverage">
     <Resource name="sql">
       <![CDATA[select name, max(name), avg(deptno), min(name)

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -1150,7 +1150,8 @@ Note:
 
 | Type     | Description                | Example literals
 |:-------- |:---------------------------|:---------------
-| ANY      | A value of an unknown type |
+| ANY      | A value of an unknown type, subject to explicit casting to maintain type consistency in expressions |
+| UNKNOWN  | A value of an unknown type, which Calcite assume's will simply work "as is" without any explicit casting |
 | ROW      | Row with 1 or more columns | Example: Row(f0 int null, f1 varchar)
 | MAP      | Collection of keys mapped to values |
 | MULTISET | Unordered collection that may contain duplicates | Example: int multiset


### PR DESCRIPTION
This PR does 2 things:

- Add a predicate to `AggregateReduceFunctionsRule`, cherry-picked from https://github.com/apache/calcite/commit/ecbafbfbd356955db08e363b71c03d8923e6fe98
- Fix a bug in the `UNKNOWN` type to prevent the type from changing when toggling nullability. There is a [PR](https://github.com/apache/calcite/pull/2595) to master for this as well, but since this is a somewhat more controversial feature, perhaps it would be better to include it in the Looker fork first.